### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This code was ported to Objective-C directly from http://janmatuschek.de/Latitud
 pod 'JPMBoundingCoordinates'
 ```
  - **Manual:**
-Copy `JPMBoundingCoordinates/JPMBoundingCoordinates` folder anywhere to your project and add it to XCode.
+Copy `JPMBoundingCoordinates/JPMBoundingCoordinates` folder anywhere to your project and add it to Xcode.
 
 
 ##Sample


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
